### PR TITLE
【可以动态设置pageSize】增加DBTable的每页面显示多少条数据的配置，不再固定50条

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -64,6 +64,8 @@ module.exports = {
 
   DBTable: {  // DBTable组件相关配置
     pageSize: 50, // 表格每页显示多少条数据
+    showSizeChanger:true, //是否可以修改每页显示多少条数据
+    pageSizeOptions:['10', '20', '50', '100'], //显示每页显示多少条数据的选项
 
     default: {  // 针对每个表格的默认配置
       showExport: true,  // 显示导出按钮, 默认true


### PR DESCRIPTION
对DBTable组件增加两个配置项：
showSizeChanger:true, //是否可以修改每页显示多少条数据，对应antd 的Pagination组件的showSizeChanger属性
pageSizeOptions:['10', '20', '50', '100'], //显示每页显示多少条数据的选项，对应antd 的Pagination组件的pageSizeOptions属性